### PR TITLE
Android 13 update

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -113,12 +113,23 @@ public class FileUtils extends CordovaPlugin {
      * Refer to: https://developer.android.com/about/versions/13/behavior-changes-13
      */
 
+    /*
+     * Since Mi-Corporation uses cordova-android version 8.0.0 which only supports up to version 28
+     * of the Android SDK, we must manually declare the new Manifest.permission constant values that were
+     * introduced later as well as the latest build constant.
+    */
+    private static final String MANIFEST_PERMISSION_READ_MEDIA_IMAGES = "android.permission.READ_MEDIA_IMAGES";
+    private static final String MANIFEST_PERMISSION_READ_MEDIA_VIDEO = "android.permission.READ_MEDIA_VIDEO";
+    private static final String MANIFEST_PERMISSION_READ_MEDIA_AUDIO = "android.permission.READ_MEDIA_AUDIO";
+    private static final int BUILD_VERSION_CODES_TIRAMISU = 33;
+
+
     private String [] permissions = {
             Manifest.permission.READ_EXTERNAL_STORAGE,
             Manifest.permission.WRITE_EXTERNAL_STORAGE,
-            Manifest.permission.READ_MEDIA_IMAGES,
-            Manifest.permission.READ_MEDIA_VIDEO,
-            Manifest.permission.READ_MEDIA_AUDIO};
+            MANIFEST_PERMISSION_READ_MEDIA_IMAGES,
+            MANIFEST_PERMISSION_READ_MEDIA_VIDEO,
+            MANIFEST_PERMISSION_READ_MEDIA_AUDIO};
 
     // This field exists only to support getEntry, below, which has been deprecated
     private static FileUtils filePlugin;
@@ -574,9 +585,9 @@ public class FileUtils extends CordovaPlugin {
 
     private void getReadPermission(String rawArgs, int action, CallbackContext callbackContext) {
         int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (android.os.Build.VERSION.SDK_INT >= BUILD_VERSION_CODES_TIRAMISU) {
             PermissionHelper.requestPermissions(this, requestCode, 
-            new String[]{Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_AUDIO});
+            new String[]{MANIFEST_PERMISSION_READ_MEDIA_IMAGES, MANIFEST_PERMISSION_READ_MEDIA_VIDEO, MANIFEST_PERMISSION_READ_MEDIA_AUDIO});
           } else {
             PermissionHelper.requestPermission(this, requestCode, Manifest.permission.READ_EXTERNAL_STORAGE);
           }
@@ -588,10 +599,10 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private boolean hasReadPermission() {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            return PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_IMAGES) 
-            && PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_VIDEO)
-            && PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_AUDIO);
+        if (android.os.Build.VERSION.SDK_INT >= BUILD_VERSION_CODES_TIRAMISU) {
+            return PermissionHelper.hasPermission(this, MANIFEST_PERMISSION_READ_MEDIA_IMAGES) 
+            && PermissionHelper.hasPermission(this, MANIFEST_PERMISSION_READ_MEDIA_VIDEO)
+            && PermissionHelper.hasPermission(this, MANIFEST_PERMISSION_READ_MEDIA_AUDIO);
           } else {
         return PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
           }

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -99,15 +99,26 @@ public class FileUtils extends CordovaPlugin {
 
     private PendingRequests pendingRequests;
 
-
-
     /*
-     * We need both read and write when accessing the storage, I think.
+     * We need both read and write when accessing the storage, I think. (SDK Version < 33)
+     * 
+     * If your app targets Android 13 (SDK 33) or higher and needs to access media files that other apps have created, 
+     * you must request one or more of the following granular media permissions 
+     * instead of the READ_EXTERNAL_STORAGE permission:
+     * 
+     * READ_MEDIA_IMAGES
+     * READ_MEDIA_VIDEO
+     * READ_MEDIA_AUDIO
+     * 
+     * Refer to: https://developer.android.com/about/versions/13/behavior-changes-13
      */
 
     private String [] permissions = {
             Manifest.permission.READ_EXTERNAL_STORAGE,
-            Manifest.permission.WRITE_EXTERNAL_STORAGE };
+            Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            Manifest.permission.READ_MEDIA_IMAGES,
+            Manifest.permission.READ_MEDIA_VIDEO,
+            Manifest.permission.READ_MEDIA_AUDIO};
 
     // This field exists only to support getEntry, below, which has been deprecated
     private static FileUtils filePlugin;
@@ -563,7 +574,12 @@ public class FileUtils extends CordovaPlugin {
 
     private void getReadPermission(String rawArgs, int action, CallbackContext callbackContext) {
         int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
-        PermissionHelper.requestPermission(this, requestCode, Manifest.permission.READ_EXTERNAL_STORAGE);
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            PermissionHelper.requestPermissions(this, requestCode, 
+            new String[]{Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_AUDIO});
+          } else {
+            PermissionHelper.requestPermission(this, requestCode, Manifest.permission.READ_EXTERNAL_STORAGE);
+          }
     }
 
     private void getWritePermission(String rawArgs, int action, CallbackContext callbackContext) {
@@ -572,7 +588,13 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private boolean hasReadPermission() {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_IMAGES) 
+            && PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_VIDEO)
+            && PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_AUDIO);
+          } else {
         return PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
+          }
     }
 
     private boolean hasWritePermission() {


### PR DESCRIPTION
### Platforms affected
android

### Motivation and Context
Added support for android 13 (API level 33). Note that this mi-corporation version of the Apache plugin was originally based on version 6.0.1 of the Apache cordova-plugin-file plugin. I applied the changes necessary to support android 13 in order to support modern android apps.

### Description
For reference I looked at the current master branch of the apache cordova-plugin-file repository and applied the necessary changes, namely requesting the permissions READ_MEDIA_IMAGES, READ_MEDIA_VIDEO, and READ_MEDIA_AUDIO in place of READ_EXTERNAL_DATA. This requirement is documented here:
https://developer.android.com/about/versions/13/behavior-changes-13

### Testing
I placed an updated copy of the corodva-plugin-file source code on my local file system and updated my config.xml and package.json files to pull cordova-plugin-file from this local folder rather than from a repote repository.

I built the main cordova app (Ideagen Smartforms) using our android build process, and installed the resulting .apk file into an Android Emulator running version android 13 (API level 33).

I tested Smartforms and confirmed from the File Attachment field I could load images and pdf files from the local file system.

